### PR TITLE
Updated .travis.yml and made test run with HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,15 @@
-language:      php
-php:           [ 5.3 ]
-before_script: composer install -n
-script:        phpunit
+language: php
+
+php:
+   - 5.3
+   - 5.4
+   - 5.5
+   - 5.6
+   - hhvm
+
+before_script:
+   - composer self-update
+   - composer install --no-interaction
+
+script:
+   - phpunit --coverage-text

--- a/Tests/Functional/ConfigTest.php
+++ b/Tests/Functional/ConfigTest.php
@@ -11,15 +11,15 @@ class ConfigTest extends WebTestCase
         $client = self::createClient();
 
         // foo - en_GB
-        $crawler = $client->request('GET', 'http://foo.example.org/page-en');
-        $this->assertContains('flag A', $crawler->text());
+        $client->request('GET', 'http://foo.example.org/page-en');
+        $this->assertContains('flag A', $client->getResponse()->getContent());
 
         // foo - fr_FR
-        $crawler = $client->request('GET', 'http://foo.example.org/fr/page-fr');
-        $this->assertNotContains('flag A', $crawler->text());
+        $client->request('GET', 'http://foo.example.org/fr/page-fr');
+        $this->assertNotContains('flag A', $client->getResponse()->getContent());
 
         // bar - fr_FR
-        $crawler = $client->request('GET', 'http://bar.example.org/page-fr');
-        $this->assertNotContains('flag B', $crawler->text());
+        $client->request('GET', 'http://bar.example.org/page-fr');
+        $this->assertNotContains('flag B', $client->getResponse()->getContent());
     }
 }

--- a/Tests/Functional/RoutingTest.php
+++ b/Tests/Functional/RoutingTest.php
@@ -19,8 +19,8 @@ class RoutingTest extends WebTestCase
         // verify every site has homepage, because homepage is not
         // multisite
         foreach ($urls as $url) {
-            $crawler = $client->request('GET', $url);
-            $this->assertContains('Test homepage', $crawler->text(), "Test ".$url);
+            $client->request('GET', $url);
+            $this->assertContains('Test homepage', $client->getResponse()->getContent(), "Test ".$url);
         }
     }
 
@@ -29,15 +29,15 @@ class RoutingTest extends WebTestCase
         $client = self::createClient();
 
         // foo - en_GB
-        $crawler = $client->request('GET', 'http://foo.example.org/page-en');
-        $this->assertContains('branding: foo, locale: en_GB', $crawler->text());
+        $client->request('GET', 'http://foo.example.org/page-en');
+        $this->assertContains('branding: foo, locale: en_GB', $client->getResponse()->getContent());
 
         // foo - fr_FR
-        $crawler = $client->request('GET', 'http://foo.example.org/fr/page-fr');
-        $this->assertContains('branding: foo, locale: fr_FR', $crawler->text());
+        $client->request('GET', 'http://foo.example.org/fr/page-fr');
+        $this->assertContains('branding: foo, locale: fr_FR', $client->getResponse()->getContent());
 
         // bar - fr_FR
-        $crawler = $client->request('GET', 'http://bar.example.org/page-fr');
-        $this->assertContains('branding: bar, locale: fr_FR', $crawler->text());
+        $client->request('GET', 'http://bar.example.org/page-fr');
+        $this->assertContains('branding: bar, locale: fr_FR', $client->getResponse()->getContent());
     }
 }

--- a/Tests/Functional/TemplatingTest.php
+++ b/Tests/Functional/TemplatingTest.php
@@ -11,15 +11,15 @@ class TemplatingTest extends WebTestCase
         $client = self::createClient();
 
         // foo - en_GB
-        $crawler = $client->request('GET', 'http://foo.example.org/page-en');
-        $this->assertContains('Foo header', $crawler->text());
+        $client->request('GET', 'http://foo.example.org/page-en');
+        $this->assertContains('Foo header', $client->getResponse()->getContent());
 
         // bar - fr_FR
-        $crawler = $client->request('GET', 'http://bar.example.org/page-fr');
-        $this->assertContains('Default header', $crawler->text());
+        $client->request('GET', 'http://bar.example.org/page-fr');
+        $this->assertContains('Default header', $client->getResponse()->getContent());
 
         // bar - de_DE
-        $crawler = $client->request('GET', 'http://de.bar.example.org/page-de');
-        $this->assertContains('German header', $crawler->text());
+        $client->request('GET', 'http://de.bar.example.org/page-de');
+        $this->assertContains('German header', $client->getResponse()->getContent());
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,7 +14,7 @@
     bootstrap                   = "autoload.php" >
 
     <testsuites>
-        <testsuite name="Project Test Suite">
+        <testsuite name="MultisiteBundle Test Suite">
             <directory>Tests</directory>
         </testsuite>
     </testsuites>
@@ -25,6 +25,7 @@
             <exclude>
                 <directory>Resources</directory>
                 <directory>Tests</directory>
+                <directory>vendor</directory>
             </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
Added more PHP Version to travis as well as HHVM.
Added composer handling of self-updates.
PHPUnit outputs the coverage as text.
Changed tests, so they do not use the DomCrawler internally, which seems to have a problem with HHVM.
