### PR TITLE
Replace Twig_LoaderInterface by Twig_Loader_Filesystem

### DIFF
--- a/Twig/MultisiteLoader.php
+++ b/Twig/MultisiteLoader.php
@@ -44,7 +44,7 @@ class MultisiteLoader extends \Twig_Loader_Filesystem
             }
         }
 
-        throw new \RuntimeException(sprintf("Template \"%s\" not found. Tried the following:\n%s", $name, implode("\n", $templates)));
+        throw new \Twig_Error_Loader(sprintf("Template \"%s\" not found. Tried the following:\n%s", $name, implode("\n", $templates)));
     }
 
     /**
@@ -61,7 +61,7 @@ class MultisiteLoader extends \Twig_Loader_Filesystem
             }
         }
 
-        throw new \RuntimeException(sprintf("Template \"%s\" not found. Tried the following:\n%s", $name, implode("\n", $templates)));
+        throw new \Twig_Error_Loader(sprintf("Template \"%s\" not found. Tried the following:\n%s", $name, implode("\n", $templates)));
     }
 
     /**
@@ -78,7 +78,7 @@ class MultisiteLoader extends \Twig_Loader_Filesystem
             }
         }
 
-        throw new \RuntimeException(sprintf("Template \"%s\" not found. Tried the following:\n%s", $name, implode("\n", $templates)));
+        throw new \Twig_Error_Loader(sprintf("Template \"%s\" not found. Tried the following:\n%s", $name, implode("\n", $templates)));
     }
 
     /**

--- a/Twig/MultisiteLoader.php
+++ b/Twig/MultisiteLoader.php
@@ -7,10 +7,10 @@ use Alex\MultisiteBundle\Branding\SiteContext;
 /**
  * Wraps a Twig Loader and extends template syntax
  */
-class MultisiteLoader implements \Twig_LoaderInterface
+class MultisiteLoader extends \Twig_Loader_Filesystem
 {
     /**
-     * @var Twig_LoaderInterface
+     * @var Twig_Loader_Filesystem
      */
     private $loader;
 


### PR DESCRIPTION
Replace Twig_LoaderInterface by Twig_Loader_Filesystem to keep Twig_Loader_Array intact

for exemple LexikMailerBundle use Twig_Loader_Array to render tempalte from the database