### PR TITLE
Detection of plain hosts

### DIFF
--- a/Branding/SiteContext.php
+++ b/Branding/SiteContext.php
@@ -158,6 +158,16 @@ class SiteContext
         return $result;
     }
 
+    public function getBrandingsWithHost($host) {
+        $locale = $this->getCurrentLocale();
+        foreach($this->brandings as $branding) {
+            if ($branding->getHost($locale) == $host) {
+                return $branding;
+            }
+        }
+        return null;
+    }
+
     /**
      * Converts an array used in annotation to an associative array branding/locale.
      *

--- a/Router/MultisiteRouter.php
+++ b/Router/MultisiteRouter.php
@@ -58,7 +58,9 @@ class MultisiteRouter extends Router
         $host = $request->getHost();
 
         $branding = $this->getSiteContext()->getBrandingsWithHost($host);
+
         if ($branding != null) {
+            $this->context->setParameter('_branding', $branding->getName());
             $this->siteContext->setCurrentBranding($branding);
         }
         return $match;

--- a/Router/MultisiteRouter.php
+++ b/Router/MultisiteRouter.php
@@ -55,7 +55,12 @@ class MultisiteRouter extends Router
     {
         $match = parent::matchRequest($request);
         $this->setMatchContext($match);
+        $host = $request->getHost();
 
+        $branding = $this->getSiteContext()->getBrandingsWithHost($host);
+        if ($branding != null) {
+            $this->siteContext->setCurrentBranding($branding);
+        }
         return $match;
     }
 

--- a/Twig/MultisiteLoader.php
+++ b/Twig/MultisiteLoader.php
@@ -54,7 +54,16 @@ class MultisiteLoader extends \Twig_Loader_Filesystem
      */
     protected function findTemplate($name)
     {
-        return $this->loader->findTemplate($name);
+        $templates = $this->getTemplates($name);
+
+        foreach ($templates as $template) {
+            try {
+                return $this->loader->findTemplate($template);
+            } catch (\Twig_Error $e) {
+            }
+        }
+
+        throw new \Twig_Error_Loader(sprintf("Template \"%s\" not found. Tried the following:\n%s", $name, implode("\n", $templates)));
     }
 
 


### PR DESCRIPTION
What I'm trying to achieve is to override templates for different *host names* only. My routes are mostly not defined in annotations but in configuration so I simply want to configure "if hostname matches xxx.yyy.zzz => switch the branding to x.y.z" and use overridden templates if you find any"

(my config:)
```
alex_multisite:
  default_branding: abc
  default_locale:   de_DE
  brandings:
    abc:
      de_DE: { host: www.abc.def }
    xyz:
      de_DE: { host: www.xyz.uvw }
```
if used like that (and no other configuration at all), I would assume that templates are located in subfolders like `_xyz_` first before falling back to the defaults but when accessing the page "www.xyz.uvw" the branding remains "abc" which I didn't expect. After taking a deeper dive I wrote the code in this PR to work around the locales/annotations but the way I'm doing it here is definitely far from optimal. It does what I want to achieve but it breaks one test (Routing::testDefaultBehaviour) with "Unable to generate a URL for the named route "test_locale" as such route does not exist." Now, obviously that route *does* exist but the routing generator might have some issue with my custom override. I can't figure out how to fix that so any ideas would be greatly appreciated.

