### PR TITLE
Issue #20 : Wrong declaration of function findTemplate in MultisiteLoader.php

### DIFF
--- a/Twig/MultisiteLoader.php
+++ b/Twig/MultisiteLoader.php
@@ -52,7 +52,7 @@ class MultisiteLoader extends \Twig_Loader_Filesystem
     /**
      * {@inheritdoc}
      */
-    protected function findTemplate($name)
+    protected function findTemplate($name, $throw = true)
     {
         return $this->loader->findTemplate($name);
     }


### PR DESCRIPTION
Adding argument '$throw = true' to function findTemplate in order to be compatible with twig version >= 2.x